### PR TITLE
Support for checking variableTree declarations using var in TreeUtils. Resolves 4170.

### DIFF
--- a/checker/tests/tainting/Issue4170.java
+++ b/checker/tests/tainting/Issue4170.java
@@ -1,0 +1,21 @@
+import java.util.ArrayList;
+import org.checkerframework.checker.tainting.qual.Tainted;
+import org.checkerframework.checker.tainting.qual.Untainted;
+
+// @below-java10-jdk-skip-test
+public class Issue4170 {
+  public void method1() {
+    var list = new ArrayList<@Untainted String>();
+    var stream = list.stream();
+  }
+
+  public void method2() {
+    var list = new ArrayList<String>();
+    var stream = list.stream();
+  }
+
+  public void method3() {
+    var list = new ArrayList<@Tainted String>();
+    var stream = list.stream();
+  }
+}

--- a/framework/tests/all-systems/Issue4170.java
+++ b/framework/tests/all-systems/Issue4170.java
@@ -1,0 +1,27 @@
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+// @below-java10-jdk-skip-test
+public class Issue4170 {
+  public <K, V> void loadSequentially(Iterable<? extends K> keys) {
+    Map<K, @Nullable V> result = new LinkedHashMap<>();
+    for (K key : keys) {
+      result.put(key, null);
+    }
+    for (var iter = result.entrySet().iterator(); iter.hasNext(); ) {
+      var entry = iter.next();
+    }
+  }
+
+  public void method1() {
+    @NonNull String s = "s";
+    var v = s;
+  }
+
+  public void method2() {
+    var s = new ArrayList<@NonNull String>();
+  }
+}

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -133,6 +133,8 @@ public final class TreeUtils {
   private static @MonotonicNonNull Method switchExpressionGetCases = null;
   /** The {@code YieldTree.getValue()} method. Null on JDK 11 and lower. */
   private static @MonotonicNonNull Method yieldGetValue = null;
+  /** The {@code JCTree.JCVariableDecl.declaredUsingVar()} method. Null on JDK 9 and lower. */
+  private static @MonotonicNonNull Method isDeclaredUsingVar = null;
 
   /** Tree kinds that represent a binary comparison. */
   private static final Set<Tree.Kind> BINARY_COMPARISON_TREE_KINDS =
@@ -176,6 +178,13 @@ public final class TreeUtils {
         yieldGetValue = yieldTreeClass.getMethod("getValue");
       } catch (ClassNotFoundException | NoSuchMethodException e) {
         throw new BugInCF("JDK 12+ reflection problem", e);
+      }
+    }
+    if (SystemUtil.jreVersion >= 10) {
+      try {
+        isDeclaredUsingVar = JCTree.JCVariableDecl.class.getDeclaredMethod("declaredUsingVar");
+      } catch (NoSuchMethodException e) {
+        throw new BugInCF("JDK 10+ reflection problem", e);
       }
     }
   }
@@ -2380,6 +2389,25 @@ public final class TreeUtils {
     } catch (InvocationTargetException | IllegalAccessException e) {
       throw new BugInCF(
           "TreeUtils.yieldTreeGetValue: reflection failed for tree: %s", yieldTree, e);
+    }
+  }
+
+  /**
+   * Returns true if the {@code variableTree} is declared using var.
+   *
+   * @param variableTree the variableTree to check
+   * @true if the variableTree is declared using var
+   */
+  public static boolean isVariableTreeDeclaredUsingVar(JCTree.JCVariableDecl variableTree) {
+    if (SystemUtil.jreVersion < 10) {
+      throw new BugInCF("Don't call JCTree.JCVariableDecl.declaredUsingVar on JDK < 10");
+    }
+    try {
+      return (boolean) isDeclaredUsingVar.invoke(variableTree);
+    } catch (InvocationTargetException | IllegalAccessException e) {
+      throw new BugInCF(
+          "TreeUtils.isVariableTreeDeclaredUsingVar: reflection failed for tree: %s",
+          variableTree, e);
     }
   }
 

--- a/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
+++ b/javacutil/src/main/java/org/checkerframework/javacutil/TreeUtils.java
@@ -2396,7 +2396,7 @@ public final class TreeUtils {
    * Returns true if the {@code variableTree} is declared using var.
    *
    * @param variableTree the variableTree to check
-   * @true if the variableTree is declared using var
+   * @return true if the variableTree is declared using var
    */
   public static boolean isVariableTreeDeclaredUsingVar(JCTree.JCVariableDecl variableTree) {
     if (SystemUtil.jreVersion < 10) {


### PR DESCRIPTION
There are some failing tests in _NullnessTest_ due to `OutOfMemoryError`. It's being caused by `KeyForAnnotatedTypeFactory` while invoking `getAnnotatedType`, seemingly with infinite recursion. 

I was wondering if `PropagationTreeAnnotator.visitVariable` should be invoked at all when `AnnotatedTypeFactory` is of type `KeyForAnnotatedTypeFactory`. And if so, are the test cases in the right directories?
Since the changes seem to be general to all checkers, assumed that they should be placed in the `tests/all-systems` directory.

However, if that's not the case, should there be any constraints on what kind of variableTrees can `KeyForAnnotatedTypeFactory` deal with and add conditions accordingly? Or should the annotation propagation have been done in some other approach?